### PR TITLE
Bug fixes for 0.10.2

### DIFF
--- a/frontend/src/components/DatasetEdit.vue
+++ b/frontend/src/components/DatasetEdit.vue
@@ -235,8 +235,8 @@ export default {
                                {
                                  'title': data.title,
                                  'description': data.description,
-                                 'tagsStandard': data.tagsStandard,
-                                 'tagsUser': data.tagsUser,
+                                 'properties': data.properties,
+                                 'tags': data.tags,
                                });
           this.isLoadingOrderData = false;
         })

--- a/frontend/src/components/OrderEdit.vue
+++ b/frontend/src/components/OrderEdit.vue
@@ -111,12 +111,6 @@ export default {
     }
   },
 
-  watch: {
-    order (newValue) {
-      this.tags = newValue;
-    }
-  },
-  
   computed: {
     order: {
       get () {


### PR DESCRIPTION
Bug fixes:
* New datasets copy order properties/tags correctly
* Remove a `watch` that created a circular object