### PR TITLE
"Accept" buttons on the left

### DIFF
--- a/frontend/src/components/UserEdit.vue
+++ b/frontend/src/components/UserEdit.vue
@@ -113,7 +113,8 @@
       </q-list>
     </q-card-section>
 
-    <q-card-section v-if="currentUser.permissions.includes('USER_MANAGEMENT') && uuid !==''">
+    <q-card-actions v-if="currentUser.permissions.includes('USER_MANAGEMENT') && uuid !==''"
+                    align="left">
       <q-btn label="Logs"
              color="primary"
              class="q-mx-sm"
@@ -127,12 +128,11 @@
                   :uuid="uuid"/>
       <action-viewer v-model="showActions"
                      :uuid="uuid" />
-    </q-card-section>
+    </q-card-actions>
 
     <q-card-actions align="right">
       <span v-show="userDataSaveError" class="text-negative">Save failed</span>
     </q-card-actions>
-
     <q-card-actions align="right">
       <q-btn v-show="uuid !== ''"
              label="Delete"
@@ -140,11 +140,12 @@
              @click="showConfirmDelete = true"
              :loading="userDataSaveWaiting"
              class="text-negative q-mr-xl" />
-      <q-btn label="Cancel" color="grey-6" v-close-popup />
+
       <q-btn label="Save"
              color="positive"
              @click="saveUser"
              :loading="userDataSaveWaiting"/>
+      <q-btn label="Cancel" color="grey-6" v-close-popup />
     </q-card-actions>
 
     <q-inner-loading :showing="isLoading">
@@ -160,12 +161,12 @@
       </q-card-section>
 
       <q-card-actions align="right">
-        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
         <q-btn flat
                :loading="isDeleting"
                label="Delete"
                color="negative"
                @click="deleteEntry" />
+        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -341,6 +342,9 @@ export default {
 
   mounted () {
     this.loadData();
+    if (!this.currentUser.permissions.includes('USER_MANAGEMENT')) {
+      this.loadPermissions()
+    }
   },
 }
 </script>

--- a/frontend/src/pages/CollectionInfo.vue
+++ b/frontend/src/pages/CollectionInfo.vue
@@ -57,18 +57,18 @@
 
       <q-btn class="q-mx-sm"
              v-show="editMode"
-             icon="cancel"
-             label="Cancel"
-             color="grey-6"
-             @click="cancelEdit" />
-
-      <q-btn class="q-ml-sm q-mr-lg"
-             v-show="editMode"
              icon="save"
              label="Save"
              color="positive"
              :loading="isSaving"
              @click="saveEdit" />
+
+      <q-btn class="q-ml-sm q-mr-lg"
+             v-show="editMode"
+             icon="cancel"
+             label="Cancel"
+             color="grey-6"
+             @click="cancelEdit" />
 
       <q-tabs v-show="editMode"
               v-model="currentTab"

--- a/frontend/src/pages/CollectionInfo.vue
+++ b/frontend/src/pages/CollectionInfo.vue
@@ -111,11 +111,12 @@
       </q-card-section>
 
       <q-card-actions align="right">
-        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
-        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
         <q-spinner v-show="isDeleting"
                    color="negative"
-                   size="1.5em" />
+                   size="1.5em"
+                   class="q-mr-sm" />
+        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
+        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -222,13 +223,15 @@ export default {
 
     deleteEntry(event) {
       event.preventDefault();
+      this.isDeleting =  true;
       this.$store.dispatch('entries/deleteEntry', {'id': this.uuid,
                                                 'dataType': this.dataType})
         .then(() => {
           this.$router.push({ 'name': 'Collection Browser' });
           this.showConfirmDelete = false;
         })
-        .catch((err) => this.error = true);
+        .catch((err) => this.error = true)
+        .finally(() => this.isDeleting = false);
     },
 
     saveEdit (event) {

--- a/frontend/src/pages/DatasetInfo.vue
+++ b/frontend/src/pages/DatasetInfo.vue
@@ -57,18 +57,18 @@
 
       <q-btn class="q-mx-sm"
              v-show="editMode"
-             icon="cancel"
-             label="Cancel"
-             color="grey-6"
-             @click="cancelEdit" />
-
-      <q-btn class="q-ml-sm q-mr-lg"
-             v-show="editMode"
              icon="save"
              label="Save"
              color="positive"
              :loading="isSaving"
              @click="saveEdit" />
+
+      <q-btn class="q-ml-sm q-mr-lg"
+             v-show="editMode"
+             icon="cancel"
+             label="Cancel"
+             color="grey-6"
+             @click="cancelEdit" />
 
       <q-tabs v-show="editMode"
               v-model="currentTab"

--- a/frontend/src/pages/DatasetInfo.vue
+++ b/frontend/src/pages/DatasetInfo.vue
@@ -111,11 +111,12 @@
       </q-card-section>
 
       <q-card-actions align="right">
-        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
-        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
         <q-spinner v-show="isDeleting"
                    color="negative"
-                   size="1.5em" />
+                   size="1.5em"
+                   class="q-mr-sm" />
+        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
+        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -215,13 +216,15 @@ export default {
 
     deleteEntry(event) {
       event.preventDefault();
+      this.isDeleting = true;
       this.$store.dispatch('entries/deleteEntry', {'id': this.uuid,
                                                    'dataType': this.dataType})
         .then(() => {
           this.$router.push({ 'name': 'Dataset Browser' });
           this.showConfirmDelete = false;
         })
-        .catch((err) => this.error = true);
+        .catch((err) => this.error = true)
+        .finally(() => this.isDeleting = false);
     },
 
     saveEdit (event) {

--- a/frontend/src/pages/OrderInfo.vue
+++ b/frontend/src/pages/OrderInfo.vue
@@ -113,11 +113,12 @@
       </q-card-section>
 
       <q-card-actions align="right">
-        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
-        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
         <q-spinner v-show="isDeleting"
                    color="negative"
-                   size="1.5em" />
+                   size="1.5em"
+                   class="q-mr-sm" />
+        <q-btn flat label="Delete" color="negative" @click="deleteEntry" />
+        <q-btn flat label="Cancel" color="grey-7" v-close-popup />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -220,13 +221,16 @@ export default {
 
     deleteEntry(event) {
       event.preventDefault();
+      this.isDeleting = true;
       this.$store.dispatch('entries/deleteEntry', {'id': this.uuid,
                                                 'dataType': this.dataType})
         .then(() => {
           this.$router.push({ 'name': 'Order Browser' });
           this.showConfirmDelete = false;
         })
-        .catch((err) => this.error = true);
+        .catch((err) => this.error = true)
+        .finally(() => this.isDeleting = false);
+      
     },
 
     saveEdit (event) {

--- a/frontend/src/pages/OrderInfo.vue
+++ b/frontend/src/pages/OrderInfo.vue
@@ -59,18 +59,18 @@
 
       <q-btn class="q-mx-sm"
              v-show="editMode"
-             icon="cancel"
-             label="Cancel"
-             color="grey-6"
-             @click="cancelEdit" />
-
-      <q-btn class="q-ml-sm q-mr-lg"
-             v-show="editMode"
              icon="save"
              label="Save"
              color="positive"
              :loading="isSaving"
              @click="saveEdit" />
+
+      <q-btn class="q-ml-sm q-mr-lg"
+             v-show="editMode"
+             icon="cancel"
+             label="Cancel"
+             color="grey-6"
+             @click="cancelEdit" />
 
       <q-tabs v-show="editMode"
               v-model="currentTab"


### PR DESCRIPTION
Swap button order in dialogs, asserting that the accept button is on the left.

Also makes sure that the spinner showing activity on the info pages is actually used.

Closes #56 