### PR TITLE
Avoid nonsense whitespace for user without extra info

### DIFF
--- a/frontend/src/components/UserEntry.vue
+++ b/frontend/src/components/UserEntry.vue
@@ -2,52 +2,54 @@
 <q-expansion-item expand-separator
                   icon="far fa-user"
                   :label="name">
-  <q-card>
-    <q-card-section>
-      <q-list dense>
-        <q-item v-show="contact.length > 0">
-          <q-item-section avatar>
-            <q-avatar>
-              <q-icon name="far fa-address-card"/>
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            {{ contact }}
-          </q-item-section>
-        </q-item>
-        <q-item v-show="affiliation.length > 0">
-          <q-item-section avatar>
-            <q-avatar>
-              <q-icon name="fas fa-university" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            {{ affiliation }}
-          </q-item-section>
-        </q-item>
-        <q-item v-show="url.length > 0">
-          <q-item-section avatar>
-            <q-avatar>
-              <q-icon name="fas fa-link" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            <a class="std-link" :href="url">{{ url }}</a>
-          </q-item-section>
-        </q-item>
-        <q-item v-show="orcid.length > 0">
-          <q-item-section avatar>
-            <q-avatar>
-              <q-icon name="fab fa-orcid" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            <a class="std-link" :href="'https://orcid.org/' + orcid">{{ orcid }}</a>
-          </q-item-section>
-        </q-item>
-      </q-list>
-    </q-card-section>
-  </q-card>
+  <q-list dense>
+    <q-item v-show="contact.length === 0 
+                    && affiliation.length === 0 
+                    && url.length === 0
+                    && orcid.length === 0">
+      <span class="text-grey">No extra information available</span>
+    </q-item>
+    <q-item v-show="contact.length > 0">
+      <q-item-section avatar>
+        <q-avatar>
+          <q-icon name="far fa-address-card"/>
+        </q-avatar>
+      </q-item-section>
+      <q-item-section>
+        {{ contact }}
+      </q-item-section>
+    </q-item>
+    <q-item v-show="affiliation.length > 0">
+      <q-item-section avatar>
+        <q-avatar>
+          <q-icon name="fas fa-university" />
+        </q-avatar>
+      </q-item-section>
+      <q-item-section>
+        {{ affiliation }}
+      </q-item-section>
+    </q-item>
+    <q-item v-show="url.length > 0">
+      <q-item-section avatar>
+        <q-avatar>
+          <q-icon name="fas fa-link" />
+        </q-avatar>
+      </q-item-section>
+      <q-item-section>
+        <a class="std-link" :href="url">{{ url }}</a>
+      </q-item-section>
+    </q-item>
+    <q-item v-show="orcid.length > 0">
+      <q-item-section avatar>
+        <q-avatar>
+          <q-icon name="fab fa-orcid" />
+        </q-avatar>
+      </q-item-section>
+      <q-item-section>
+        <a class="std-link" :href="'https://orcid.org/' + orcid">{{ orcid }}</a>
+      </q-item-section>
+    </q-item>
+  </q-list>
 </q-expansion-item>
 </template>
 


### PR DESCRIPTION
Show "No extra information available" if there is no extra information about the user.

Closes #63 